### PR TITLE
[INFRA-541]

### DIFF
--- a/brambl/consts.py
+++ b/brambl/consts.py
@@ -5,6 +5,7 @@ BLAKE2B256_DIGEST_SIZE = 32
 TRANSACTION_ID_SIZE = BLAKE2B256_DIGEST_SIZE + 1
 TRANSACTION_MODIFIER_TYPE = 2
 
+
 class PropositionType(enum.IntEnum):
     """
     Represents Topl proposition types
@@ -15,3 +16,10 @@ class PropositionType(enum.IntEnum):
     PUBLICKEYCURVE25519 = 1
     THRESHOLDKEYCURVE25519 = 2
     PUBLICKEYED25519 = 3
+
+
+TOPLNET = 'Mainnet';
+TOPLNET_FEE = 1000000000;
+VALHALLA = 'ValhallaTestnet';
+VALHALLA_FEE = 100;
+PRIVATE = 'PrivateTestnet';

--- a/brambl/requests.py
+++ b/brambl/requests.py
@@ -1,6 +1,6 @@
 import os
 # Dependencies
-from typing import Any, Union, Callable, TypedDict
+from typing import Any, Union, Callable
 
 import requests_cache
 from hexbytes import HexBytes

--- a/brambl/requests.py
+++ b/brambl/requests.py
@@ -1,12 +1,13 @@
 import os
 # Dependencies
-from typing import Any, Union, Callable
+from typing import Any, Union, Callable, TypedDict
 
 import requests_cache
 from hexbytes import HexBytes
 from requests import Timeout
 from toolz import assoc
 
+from brambl.consts import VALHALLA_FEE, TOPLNET, VALHALLA, TOPLNET_FEE
 from brambl.credentials.credential_manager import Ed25519CredentialManager
 from brambl.ed25519.utils.address import Address, validateAddressByNetwork
 from brambl.exceptions import TimeExhausted
@@ -15,7 +16,7 @@ from brambl.module import Module
 from brambl.types import URI, BlockIdentifier, AssetTxParams, ArbitTxParams, \
     PolyTxParams, AssetRawTxParams, \
     ArbitRawTxParams, PolyRawTxParams, RPCResponse, ModifierId, BlockData, \
-    BlockNumber, Transaction
+    BlockNumber, Transaction, Poly
 from brambl.utils.blocks import select_method_for_block_identifier
 from brambl.utils.empty import Empty, empty
 from brambl.utils.rpc_api import RPC
@@ -28,7 +29,6 @@ class BaseBifrostRequest(Module):
     _default_network: str = "private"
 
     """ properties """
-
     @property
     def default_block(self) -> BlockIdentifier:
         return self._default_block
@@ -54,6 +54,17 @@ class BaseBifrostRequest(Module):
                                     str(self.default_address))
 
         return transaction
+
+
+    def _estimate_fee_helper(self,
+                            network_prefix: str
+                            ) -> Poly:
+        if network_prefix == VALHALLA:
+            return Poly(VALHALLA_FEE)
+        elif network_prefix == TOPLNET:
+            return Poly(TOPLNET_FEE)
+        else
+            return Poly(0)
 
     _send_transaction: \
         Method[Callable[[Union[PolyTxParams, ArbitTxParams, AssetTxParams]],
@@ -190,6 +201,8 @@ class BifrostRequest(BaseBifrostRequest, Module):
                                    transaction: ArbitRawTxParams) -> RPCResponse:
         return self._send_raw_arbit_transaction(transaction)
 
+    def estimate_fee(self, network_prefix: str) -> Poly:
+        return self._estimate_fee_helper(network_prefix)
 
 def get_default_http_endpoint() -> URI:
     return URI(

--- a/brambl/requests.py
+++ b/brambl/requests.py
@@ -29,6 +29,7 @@ class BaseBifrostRequest(Module):
     _default_network: str = "private"
 
     """ properties """
+
     @property
     def default_block(self) -> BlockIdentifier:
         return self._default_block
@@ -55,15 +56,14 @@ class BaseBifrostRequest(Module):
 
         return transaction
 
-
     def _estimate_fee_helper(self,
-                            network_prefix: str
-                            ) -> Poly:
+                             network_prefix: str
+                             ) -> Poly:
         if network_prefix == VALHALLA:
             return Poly(VALHALLA_FEE)
         elif network_prefix == TOPLNET:
             return Poly(TOPLNET_FEE)
-        else
+        else:
             return Poly(0)
 
     _send_transaction: \
@@ -203,6 +203,7 @@ class BifrostRequest(BaseBifrostRequest, Module):
 
     def estimate_fee(self, network_prefix: str) -> Poly:
         return self._estimate_fee_helper(network_prefix)
+
 
 def get_default_http_endpoint() -> URI:
     return URI(


### PR DESCRIPTION
## Purpose

1.) Add a method to the Requests module to estimate the fee for a given request given the default presets for each network. 

## Approach

1.) Currently, these values are hard-coded in the BramblPy client, but the future expansion will include the ability to derive the fee from the node itself

## Testing

Manual testing, simple method

## Tickets
INFRA-541
